### PR TITLE
Fix for cholesky decomposition if matrix elements are small

### DIFF
--- a/src/chol_bfgs.jl
+++ b/src/chol_bfgs.jl
@@ -136,7 +136,7 @@ function step!(optfn!::F, M::CholBFGS; constrain_step=infstep) where {F}
         γ .= g .- gpre
         δ .= x .- xpre
 
-        U = UpperTriangular(H.factors)
+        U = LowerTriangular(H.factors)'
         #=
         H = H.U' * H.U
         d <- H.U * δ

--- a/src/chol_bfgs.jl
+++ b/src/chol_bfgs.jl
@@ -24,7 +24,7 @@ function CholBFGS(x::AbstractVector{T}) where {T}
     for j in 1:n, i in 1:n
         m[i,j] = (i == j)
     end
-    cm = cholesky!(m)
+    cm = Cholesky(m, 'U', 0)
     return CholBFGS(
         cm,
         similar(x, F),
@@ -136,7 +136,7 @@ function step!(optfn!::F, M::CholBFGS; constrain_step=infstep) where {F}
         γ .= g .- gpre
         δ .= x .- xpre
 
-        U = LowerTriangular(H.factors)'
+        U = UpperTriangular(H.factors)
         #=
         H = H.U' * H.U
         d <- H.U * δ

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -37,7 +37,7 @@ end
 """
     mcholesky!(A::AbstractMatrix)
 
-Perform an in-place modified Cholesky decomposition on matrix `A`
+Perform an in-place modified Cholesky decomposition on matrix `A` (column-major version)
 (Gill, Murray, Wright, Practical optimization (1981), p.111)
 """
 function mcholesky!(A::AbstractMatrix{T}; δ = convert(T, 1e-3)) where T
@@ -46,29 +46,27 @@ function mcholesky!(A::AbstractMatrix{T}; δ = convert(T, 1e-3)) where T
     ν = max(1, sqrt(n^2 - 1))
     β² = max(γ, ξ / ν, eps(T))
     θ = zero(T)
-    u = UpperTriangular(A)
-    c = u
+    l = LowerTriangular(A)
+    c = l
+    δA = δ * min(1, maximum(abs(A[i,i]) for i in 1:n))
     @inbounds for j in 1:n
-        c_jj = A[j,j]
+        c_jj = c[j,j]
         θ = zero(c_jj)
         for k in 1:j-1
-            u[k,j] /= u[k,k]
-        end
-        for i in j+1:n
-            c_ij = c[j,i]
-            for k in 1:j-1
-                c_ij -= u[k,j] * c[k,i] / u[k,k]
+            ljk = l[j,k]
+            for i in j:n
+                c[i,j] -= ljk * l[i,k]
             end
-            θ = max(abs(c_ij), θ)
-            c[j,i] = c_ij
+            θ = max(abs(c[j,k]), θ)
         end
-        d_j = max(abs(c_jj), θ^2 / β², δ)
-        u[j,j] = sqrt(d_j)
+        d_j = max(abs(A[j,j]), θ^2 / β², δA)
+        scjj = sqrt(d_j)
+        A[j,j] = scjj
         for i in j+1:n
-            c[i,i] -= (c[j,i] / u[j,j])^2
+            c[i,j] = l[i,j] / scjj
         end
     end
-    return Cholesky(A, 'U', 0)
+    return Cholesky(A, 'L', 0)
 end
 
 


### PR DESCRIPTION
The minimum magnitude of the diagonal element is scaled by the initial matrix diagonal elements